### PR TITLE
Set a timeout on the build runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
         go-version: [1.13.x]
         platform: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
+    timeout-minutes: 5
     env:
       GO111MODULE: on
     steps:


### PR DESCRIPTION
Reduce the timeout from the default `360 minutes` to `5 minutes`. Builds should not take longer than 5 minutes to complete regardless of the environment.

It is reasonable to assume any longer duration is a build failure or infrastructure issue.