### PR TITLE
Support MacOS in the build matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.13.x]
-        platform: [ubuntu-latest, windows-latest]
+        platform: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     env:
       GO111MODULE: on


### PR DESCRIPTION
Support MacOS in the build matrix as a first step in re-introducing support for MacOS binaries.

The switch to GitHub Actions saw the removal of the MacOS binaries, but this is the first step in the re-introduction of these binaries.