### PR TITLE
Support building & uploading binary artifacts to GitHub Artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,14 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
         uses: actions/checkout@v1
+      - name: Build
+        run: go build -o bmx ./cmd/bmx/.
       - name: Vet
         run: go vet ./...
       - name: Test
         run: go test -v -covermode="count" -coverprofile="profile.cov" ./...
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: bmx-${{ matrix.platform }}
+          path: bmx

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,5 +35,5 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: bmx-${{ matrix.platform }}
+          name: bmx-${{ matrix.platform }}-${{ matrix.go-version }}
           path: bmx


### PR DESCRIPTION
Support binary artifacts for all platforms and go versions defined in the build pipeline.

These artifacts can then be used for validation or testing in non-build/developer environments.  As per GitHub Artifacts default policy these artifacts will expire after 90 days.