### PR TITLE
Support caching of the go modules

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,16 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
         uses: actions/checkout@v1
+      - name: Cache Go modules
+        uses: actions/cache@v2
+        with:
+          path: |
+            $GOPATH/pkg/mod/cache/
+          key: ${{ runner.os }}-build-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.OS }}-build-${{ env.cache-name }}-
+            ${{ runner.OS }}-build-
+            ${{ runner.OS }}-
       - name: Vet
         run: go vet ./...
       - name: Test


### PR DESCRIPTION
Support caching of the downloaded go modules based on the go.sum file.

The local vendor/ files are still included but are expected to be removed in a later changeset.