### PR TITLE
Use forked repository for module path

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ BMX prints detailed usage information when you run `bmx -h` or `bmx <cmd> -h`.
 
 ## Installation
 
-Available versions of BMX are available on the [releases](https://github.com/Brightspace/bmx/releases) page. 
+Available versions of BMX are available on the [releases](https://github.com/jrbeverly/bmx/releases) page. 
 
 ## Features
 
@@ -57,18 +57,18 @@ BMX is designed to be extensible and easily rolled out.
 ### Developer Setup
 
 ```sh
-go get github.com/Brightspace/bmx
+go get github.com/jrbeverly/bmx
 ```
 
 ### Building
 
 ```bash
-go build github.com/Brightspace/bmx/cmd/bmx
+go build github.com/jrbeverly/bmx/cmd/bmx
 ```
 
 ### Getting Involved
 
-BMX has [issues](https://github.com/Brightspace/bmx/issues).
+BMX has [issues](https://github.com/jrbeverly/bmx/issues).
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 

--- a/cmd/bmx/bmx.go
+++ b/cmd/bmx/bmx.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Brightspace/bmx/config"
+	"github.com/jrbeverly/bmx/config"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/bmx/print.go
+++ b/cmd/bmx/print.go
@@ -20,11 +20,11 @@ import (
 	"log"
 	"fmt"
 
-	"github.com/Brightspace/bmx/config"
+	"github.com/jrbeverly/bmx/config"
 
-	"github.com/Brightspace/bmx/saml/identityProviders/okta"
+	"github.com/jrbeverly/bmx/saml/identityProviders/okta"
 
-	"github.com/Brightspace/bmx"
+	"github.com/jrbeverly/bmx"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/bmx/write.go
+++ b/cmd/bmx/write.go
@@ -19,10 +19,10 @@ package main
 import (
 	"log"
 
-	"github.com/Brightspace/bmx/config"
-	"github.com/Brightspace/bmx/saml/identityProviders/okta"
+	"github.com/jrbeverly/bmx/config"
+	"github.com/jrbeverly/bmx/saml/identityProviders/okta"
 
-	"github.com/Brightspace/bmx"
+	"github.com/jrbeverly/bmx"
 	"github.com/spf13/cobra"
 )
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/Brightspace/bmx/config"
+	"github.com/jrbeverly/bmx/config"
 	"github.com/magiconair/properties/assert"
 )
 

--- a/console.go
+++ b/console.go
@@ -22,10 +22,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/Brightspace/bmx/console"
-	"github.com/Brightspace/bmx/saml/identityProviders"
-	"github.com/Brightspace/bmx/saml/identityProviders/okta"
-	"github.com/Brightspace/bmx/saml/serviceProviders"
+	"github.com/jrbeverly/bmx/console"
+	"github.com/jrbeverly/bmx/saml/identityProviders"
+	"github.com/jrbeverly/bmx/saml/identityProviders/okta"
+	"github.com/jrbeverly/bmx/saml/serviceProviders"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Brightspace/bmx
+module github.com/jrbeverly/bmx
 
 go 1.14
 

--- a/mocks/mokta.go
+++ b/mocks/mokta.go
@@ -19,7 +19,7 @@ package mocks
 import (
 	"net/url"
 
-	"github.com/Brightspace/bmx/saml/identityProviders/okta"
+	"github.com/jrbeverly/bmx/saml/identityProviders/okta"
 )
 
 type Mokta struct {

--- a/print.go
+++ b/print.go
@@ -20,10 +20,10 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/Brightspace/bmx/saml/identityProviders"
+	"github.com/jrbeverly/bmx/saml/identityProviders"
 
-	"github.com/Brightspace/bmx/saml/serviceProviders"
-	"github.com/Brightspace/bmx/saml/serviceProviders/aws"
+	"github.com/jrbeverly/bmx/saml/serviceProviders"
+	"github.com/jrbeverly/bmx/saml/serviceProviders/aws"
 	"github.com/aws/aws-sdk-go/service/sts"
 )
 

--- a/print_test.go
+++ b/print_test.go
@@ -20,8 +20,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Brightspace/bmx"
-	"github.com/Brightspace/bmx/mocks"
+	"github.com/jrbeverly/bmx"
+	"github.com/jrbeverly/bmx/mocks"
 )
 
 func assertAwsTokenEnv(t *testing.T, output string) {

--- a/saml/identityProviders/IdentityProvider.go
+++ b/saml/identityProviders/IdentityProvider.go
@@ -17,7 +17,7 @@ limitations under the License.
 package identityProviders
 
 import (
-	"github.com/Brightspace/bmx/saml/identityProviders/okta"
+	"github.com/jrbeverly/bmx/saml/identityProviders/okta"
 )
 
 type IdentityProvider interface {

--- a/saml/identityProviders/okta/mocks/mocks.go
+++ b/saml/identityProviders/okta/mocks/mocks.go
@@ -17,7 +17,7 @@ limitations under the License.
 package mocks
 
 import (
-	"github.com/Brightspace/bmx/saml/identityProviders/okta/file"
+	"github.com/jrbeverly/bmx/saml/identityProviders/okta/file"
 )
 
 type SessionCache struct {

--- a/saml/identityProviders/okta/okta.go
+++ b/saml/identityProviders/okta/okta.go
@@ -30,8 +30,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Brightspace/bmx/console"
-	"github.com/Brightspace/bmx/saml/identityProviders/okta/file"
+	"github.com/jrbeverly/bmx/console"
+	"github.com/jrbeverly/bmx/saml/identityProviders/okta/file"
 	"golang.org/x/net/html"
 	"golang.org/x/net/publicsuffix"
 )

--- a/saml/identityProviders/okta/okta_test.go
+++ b/saml/identityProviders/okta/okta_test.go
@@ -24,9 +24,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Brightspace/bmx/saml/identityProviders/okta"
-	"github.com/Brightspace/bmx/saml/identityProviders/okta/file"
-	"github.com/Brightspace/bmx/saml/identityProviders/okta/mocks"
+	"github.com/jrbeverly/bmx/saml/identityProviders/okta"
+	"github.com/jrbeverly/bmx/saml/identityProviders/okta/file"
+	"github.com/jrbeverly/bmx/saml/identityProviders/okta/mocks"
 )
 
 var (

--- a/saml/serviceProviders/aws/provider.go
+++ b/saml/serviceProviders/aws/provider.go
@@ -24,7 +24,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/Brightspace/bmx/console"
+	"github.com/jrbeverly/bmx/console"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"

--- a/saml/serviceProviders/aws/provider_test.go
+++ b/saml/serviceProviders/aws/provider_test.go
@@ -20,13 +20,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Brightspace/bmx/mocks"
+	"github.com/jrbeverly/bmx/mocks"
 
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 
 	"github.com/aws/aws-sdk-go/aws"
 
-	awsService "github.com/Brightspace/bmx/saml/serviceProviders/aws"
+	awsService "github.com/jrbeverly/bmx/saml/serviceProviders/aws"
 	"github.com/aws/aws-sdk-go/service/sts"
 )
 

--- a/write.go
+++ b/write.go
@@ -21,8 +21,8 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/Brightspace/bmx/saml/identityProviders"
-	"github.com/Brightspace/bmx/saml/serviceProviders"
+	"github.com/jrbeverly/bmx/saml/identityProviders"
+	"github.com/jrbeverly/bmx/saml/serviceProviders"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"gopkg.in/ini.v1"
 )


### PR DESCRIPTION
Use the fork repository path for module path.

This helps with some grep work and avoids some mismatching when performing a couple of build relation actions.