### PR TITLE
Move :bmx to root to simplify build

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,8 +1,14 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@bazel_gazelle//:def.bzl", "gazelle")
 
 # gazelle:prefix github.com/jrbeverly/bmx
 gazelle(name = "gazelle")
+
+go_binary(
+    name = "bmx",
+    embed = ["//cmd/bmx:go_default_library"],
+    visibility = ["//visibility:public"],
+)
 
 go_library(
     name = "go_default_library",

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ go get github.com/jrbeverly/bmx
 
 ```bash
 go build github.com/jrbeverly/bmx/cmd/bmx
+
+bazel build --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //:bmx
+bazel build --platforms=@io_bazel_rules_go//go/toolchain:windows_amd64 //:bmx
+bazel build --platforms=@io_bazel_rules_go//go/toolchain:darwin_amd64 //:bmx
 ```
 
 ### Getting Involved

--- a/cmd/bmx/BUILD.bazel
+++ b/cmd/bmx/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
@@ -9,17 +9,11 @@ go_library(
         "write.go",
     ],
     importpath = "github.com/jrbeverly/bmx/cmd/bmx",
-    visibility = ["//visibility:private"],
+    visibility = ["//visibility:public"],
     deps = [
         "//:go_default_library",
         "//config:go_default_library",
         "//saml/identityProviders/okta:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
     ],
-)
-
-go_binary(
-    name = "bmx",
-    embed = [":go_default_library"],
-    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
The build target `:bmx` should be contained at root to simplify the binary compilation.

Additionally document the process for cross-platform compilation.