### PR TITLE
Implement the nogo target for source analysis

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -40,7 +40,7 @@ go_test(
 )
 
 nogo(
-    name = "nogo_vet",
+    name = "nogo",
     config = "nogo_config.json",
     visibility = ["//visibility:public"],
     deps = [

--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test", "nogo")
 load("@bazel_gazelle//:def.bzl", "gazelle")
 
 # gazelle:prefix github.com/jrbeverly/bmx
@@ -37,4 +37,31 @@ go_test(
     srcs = ["print_test.go"],
     embed = [":go_default_library"],
     deps = ["//mocks:go_default_library"],
+)
+
+nogo(
+    name = "nogo_vet",
+    config = "nogo_config.json",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@org_golang_x_tools//go/analysis/passes/asmdecl:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/assign:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/atomic:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/bools:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/buildtag:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/composite:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/copylock:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/httpresponse:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/loopclosure:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/lostcancel:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/nilfunc:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/printf:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/shift:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/stdmethods:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/structtag:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/tests:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/unreachable:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/unsafeptr:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/unusedresult:go_tool_library",
+    ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,7 +15,9 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 
 go_rules_dependencies()
 
-go_register_toolchains()
+go_register_toolchains(
+    nogo = "@//:nogo_vet",
+)
 
 http_archive(
     name = "bazel_gazelle",

--- a/nogo_config.json
+++ b/nogo_config.json
@@ -1,0 +1,7 @@
+{
+    "unreachable": {
+      "exclude_files": {
+        "external/": "external dependencies"
+      }
+    }
+  }


### PR DESCRIPTION
Support a series of default source analysis tools that are similar to those performed by `go vet`.