### PR TITLE
Remove the invalid bazel register macro

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,9 +15,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 
 go_rules_dependencies()
 
-go_register_toolchains(
-    nogo = "@//:nogo_vet",
-)
+go_register_toolchains()
 
 http_archive(
     name = "bazel_gazelle",


### PR DESCRIPTION
Resolve invalid bazel syntax in the nogo configuration introduced in 4bc031126099e8a6288ec96a02ef213dc845eaff.

Previous work for implementing nogo as part of the bazel build system introduced a import error with the action `@nogo_vet`. This isn't imported and has not been configured.

This change removes that syntax error, and resolves the bazel build back into a working state.