### PR TITLE
Support push mfa factor when authenticating

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,14 +1,8 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test", "nogo")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test", "nogo")
 load("@bazel_gazelle//:def.bzl", "gazelle")
 
 # gazelle:prefix github.com/jrbeverly/bmx
 gazelle(name = "gazelle")
-
-go_binary(
-    name = "bmx",
-    embed = ["//cmd/bmx:go_default_library"],
-    visibility = ["//visibility:public"],
-)
 
 go_library(
     name = "go_default_library",

--- a/cmd/bmx/BUILD.bazel
+++ b/cmd/bmx/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
     name = "go_default_library",
@@ -16,4 +16,10 @@ go_library(
         "//saml/identityProviders/okta:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
     ],
+)
+
+go_binary(
+    name = "bmx",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
 )

--- a/print.go
+++ b/print.go
@@ -22,9 +22,9 @@ import (
 
 	"github.com/jrbeverly/bmx/saml/identityProviders"
 
+	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/jrbeverly/bmx/saml/serviceProviders"
 	"github.com/jrbeverly/bmx/saml/serviceProviders/aws"
-	"github.com/aws/aws-sdk-go/service/sts"
 )
 
 var (

--- a/saml/identityProviders/okta/okta.go
+++ b/saml/identityProviders/okta/okta.go
@@ -278,6 +278,7 @@ func (o *OktaClient) doMfa(oktaAuthResponse *OktaAuthResponse) error {
 		if mfaIdx, err = o.ConsoleReader.ReadInt("Select an available MFA option: "); err != nil {
 			log.Fatal(err)
 		}
+		selectedFactor := oktaAuthResponse.Embedded.Factors[mfaIdx]
 		vurl := oktaAuthResponse.Embedded.Factors[mfaIdx].Links.Verify.Url
 
 		body := fmt.Sprintf(`{"stateToken":"%s"}`, oktaAuthResponse.StateToken)
@@ -292,19 +293,41 @@ func (o *OktaClient) doMfa(oktaAuthResponse *OktaAuthResponse) error {
 			log.Fatal(err)
 		}
 
-		var code string
-		if code, err = o.ConsoleReader.ReadLine("Code: "); err != nil {
-			log.Fatal(err)
-		}
-		body = fmt.Sprintf(`{"stateToken":"%s","passCode":"%s"}`, oktaAuthResponse.StateToken, code)
-		authResponse, err = o.HttpClient.Post(vurl, "application/json", strings.NewReader(body))
-		if err != nil {
-			log.Fatal(err)
-		}
+		if selectedFactor.FactorType == "token:software:totp" {
+			var code string
+			if code, err = o.ConsoleReader.ReadLine("Code: "); err != nil {
+				log.Fatal(err)
+			}
+			body = fmt.Sprintf(`{"stateToken":"%s","passCode":"%s"}`, oktaAuthResponse.StateToken, code)
+			authResponse, err = o.HttpClient.Post(vurl, "application/json", strings.NewReader(body))
+			if err != nil {
+				log.Fatal(err)
+			}
 
-		z, _ = ioutil.ReadAll(authResponse.Body)
-		if err := json.Unmarshal(z, &oktaAuthResponse); err != nil {
-			log.Fatal(err)
+			z, _ = ioutil.ReadAll(authResponse.Body)
+			if err := json.Unmarshal(z, &oktaAuthResponse); err != nil {
+				log.Fatal(err)
+			}
+		} else if selectedFactor.FactorType == "push" {
+			verified := false
+			for !verified {
+				body = fmt.Sprintf(`{"stateToken":"%s"}`, oktaAuthResponse.StateToken)
+				authResponse, err = o.HttpClient.Post(vurl, "application/json", strings.NewReader(body))
+				if err != nil {
+					log.Fatal(err)
+				}
+
+				z, _ = ioutil.ReadAll(authResponse.Body)
+				if err := json.Unmarshal(z, &oktaAuthResponse); err != nil {
+					log.Fatal(err)
+				}
+
+				if oktaAuthResponse.Status == "SUCCESS" {
+					verified = true
+				} else if oktaAuthResponse.Status == "MFA_CHALLENGE" || oktaAuthResponse.Status == "WAITING" {
+					time.Sleep(8 * time.Second)
+				}
+			}
 		}
 	}
 	return nil

--- a/saml/identityProviders/okta/okta.go
+++ b/saml/identityProviders/okta/okta.go
@@ -338,6 +338,10 @@ func (o *OktaClient) doMfa(oktaAuthResponse *OktaAuthResponse) error {
 			log.Fatal(err)
 		}
 
+		// This is a rough outline and can be better organized. For now
+		// I'm comfortable with adding in this kind of handling for
+		// multiple MFA factors. I'd like for this to be done in a
+		// mapped action form (e.g. actions[factortype] => perform action)
 		if selectedFactor.FactorType == "token:software:totp" {
 			err = o.verifyTotpMfa(oktaAuthResponse, selectedFactor)
 			if err != nil {

--- a/write.go
+++ b/write.go
@@ -21,9 +21,9 @@ import (
 	"os"
 	"runtime"
 
+	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/jrbeverly/bmx/saml/identityProviders"
 	"github.com/jrbeverly/bmx/saml/serviceProviders"
-	"github.com/aws/aws-sdk-go/service/sts"
 	"gopkg.in/ini.v1"
 )
 


### PR DESCRIPTION
Support the `push` factor type when authenticating with okta.

This change moves from supporting just `totp`, to working with the push factor type. This requires some additional timeout and retry logic, as polling is needed to see is the push action has been verified. This has been manually rolled, rather than using a library, which is not ideal.

Tests have been excluded at this time, as these changes are part of a rapid fire series of changes with the aim of bringing `bmx` in compliance with a MacOS & Okta push oriented environment. Future work will be responsible for bringing this up to a better standard of development. 

