### PR TITLE
Support `credential-process` for use by awscli configured profiles

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -8,6 +8,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "console.go",
+        "credential-process.go",
         "print.go",
         "print_unix.go",
         "print_windows.go",

--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ go get github.com/jrbeverly/bmx
 ```bash
 go build github.com/jrbeverly/bmx/cmd/bmx
 
-bazel build --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //:bmx
-bazel build --platforms=@io_bazel_rules_go//go/toolchain:windows_amd64 //:bmx
-bazel build --platforms=@io_bazel_rules_go//go/toolchain:darwin_amd64 //:bmx
+bazel build --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //cmd/bmx:bmx
+bazel build --platforms=@io_bazel_rules_go//go/toolchain:windows_amd64 //cmd/bmx:bmx
+bazel build --platforms=@io_bazel_rules_go//go/toolchain:darwin_amd64 //cmd/bmx:bmx
 ```
 
 ### Getting Involved

--- a/cmd/bmx/BUILD.bazel
+++ b/cmd/bmx/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "bmx.go",
+        "credential-process.go",
         "print.go",
         "version.go",
         "write.go",

--- a/cmd/bmx/credential-process.go
+++ b/cmd/bmx/credential-process.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2019 D2L Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package main
 
 import (

--- a/cmd/bmx/credential-process.go
+++ b/cmd/bmx/credential-process.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2019 D2L Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/jrbeverly/bmx/config"
+
+	"github.com/jrbeverly/bmx/saml/identityProviders/okta"
+
+	"github.com/jrbeverly/bmx"
+	"github.com/spf13/cobra"
+)
+
+var processOptions = bmx.CredentialProcessCmdOptions{}
+
+func init() {
+	processCmd.Flags().StringVar(&processOptions.Org, "org", "", "the okta org api to target")
+	processCmd.Flags().StringVar(&processOptions.User, "user", "", "the user to authenticate with")
+	processCmd.Flags().StringVar(&processOptions.Account, "account", "", "the account name to auth against")
+	processCmd.Flags().StringVar(&processOptions.Role, "role", "", "the desired role to assume")
+	processCmd.Flags().BoolVar(&processOptions.NoMask, "nomask", false, "set to not mask the password. this helps with debugging.")
+	processCmd.Flags().StringVar(&processOptions.Output, "output", "", "the output format [bash|powershell]")
+
+	if userConfig.Org == "" {
+		processCmd.MarkFlagRequired("org")
+	}
+
+	rootCmd.AddCommand(processCmd)
+}
+
+var processCmd = &cobra.Command{
+	Use:   "credential-process",
+	Short: "Credentials to awscli",
+	Long:  `Supply the credentials in compatible format`,
+	Run: func(cmd *cobra.Command, args []string) {
+		mergedOptions := mergeProcessOptions(userConfig, processOptions)
+
+		oktaClient, err := okta.NewOktaClient(mergedOptions.Org)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		command := bmx.CredentialProcess(oktaClient, mergedOptions)
+		fmt.Println(command)
+	},
+}
+
+func mergeProcessOptions(uc config.UserConfig, pc bmx.CredentialProcessCmdOptions) bmx.CredentialProcessCmdOptions {
+	if pc.Org == "" {
+		pc.Org = uc.Org
+	}
+	if pc.User == "" {
+		pc.User = uc.User
+	}
+	if pc.Account == "" {
+		pc.Account = uc.Account
+	}
+	if pc.Role == "" {
+		pc.Role = uc.Role
+	}
+
+	return pc
+}

--- a/console.go
+++ b/console.go
@@ -19,7 +19,6 @@ package bmx
 import (
 	"fmt"
 	"log"
-	"os"
 	"strings"
 
 	"github.com/jrbeverly/bmx/console"
@@ -69,7 +68,7 @@ func getPassword(noMask bool) string {
 		if err != nil {
 			log.Fatal(err)
 		}
-		fmt.Fprintln(os.Stderr)
+		// fmt.Fprintln(os.Stderr)
 	}
 	return pass
 }
@@ -95,10 +94,10 @@ func authenticate(user serviceProviders.UserInfo, oktaClient identityProviders.I
 	app, found := findApp(user.Account, oktaApplications)
 	if !found {
 		// select an account
-		fmt.Fprintln(os.Stderr, "Available accounts:")
+		ConsoleReader.Println("Available accounts:")
 		for idx, a := range oktaApplications {
 			if a.AppName == "amazon_aws" {
-				os.Stderr.WriteString(fmt.Sprintf("[%d] %s\n", idx, a.Label))
+				ConsoleReader.Println(fmt.Sprintf("[%d] %s", idx, a.Label))
 			}
 		}
 		var accountId int

--- a/console/BUILD.bazel
+++ b/console/BUILD.bazel
@@ -2,7 +2,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["ConsoleReader.go"],
+    srcs = [
+        "ConsoleReader.go",
+        "ConsoleReader_unix.go",
+        "ConsoleReader_windows.go",
+    ],
     importpath = "github.com/jrbeverly/bmx/console",
     visibility = ["//visibility:public"],
     deps = ["@org_golang_x_crypto//ssh/terminal:go_default_library"],

--- a/console/ConsoleReader.go
+++ b/console/ConsoleReader.go
@@ -18,14 +18,14 @@ type ConsoleReader interface {
 type DefaultConsoleReader struct{}
 
 func (r DefaultConsoleReader) Println(prompt string) error {
-	outf := NewWriter()
+	outf := NewPromptWriter()
 	fmt.Fprintln(outf, prompt)
 	return nil
 }
 
 func (r DefaultConsoleReader) ReadLine(prompt string) (string, error) {
 	scanner := NewScanner()
-	outf := NewWriter()
+	outf := NewPromptWriter()
 	fmt.Fprint(outf, prompt)
 	var s string
 	scanner.Scan()
@@ -52,7 +52,7 @@ func (r DefaultConsoleReader) ReadInt(prompt string) (int, error) {
 }
 
 func (r DefaultConsoleReader) ReadPassword(prompt string) (string, error) {
-	outf := NewWriter()
+	outf := NewPromptWriter()
 	fmt.Fprint(outf, prompt)
 	pass, err := terminal.ReadPassword(int(syscall.Stdin))
 

--- a/console/ConsoleReader.go
+++ b/console/ConsoleReader.go
@@ -12,24 +12,10 @@ type ConsoleReader interface {
 	ReadLine(prompt string) (string, error)
 	ReadPassword(prompt string) (string, error)
 	ReadInt(prompt string) (int, error)
-	Prompt(prompt string) error
 	Println(prompt string) error
-	Print(prompt string) error
 }
 
 type DefaultConsoleReader struct{}
-
-func (r DefaultConsoleReader) Prompt(prompt string) error {
-	outf := NewWriter()
-	fmt.Fprintln(outf, prompt)
-	return nil
-}
-
-func (r DefaultConsoleReader) Print(prompt string) error {
-	outf := NewWriter()
-	fmt.Fprint(outf, prompt)
-	return nil
-}
 
 func (r DefaultConsoleReader) Println(prompt string) error {
 	outf := NewWriter()

--- a/console/ConsoleReader.go
+++ b/console/ConsoleReader.go
@@ -1,25 +1,7 @@
-/*
-Copyright 2019 D2L Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package console
 
 import (
-	"bufio"
 	"fmt"
-	"os"
 	"strconv"
 	"syscall"
 
@@ -30,13 +12,35 @@ type ConsoleReader interface {
 	ReadLine(prompt string) (string, error)
 	ReadPassword(prompt string) (string, error)
 	ReadInt(prompt string) (int, error)
+	Prompt(prompt string) error
+	Println(prompt string) error
+	Print(prompt string) error
 }
 
 type DefaultConsoleReader struct{}
 
+func (r DefaultConsoleReader) Prompt(prompt string) error {
+	outf := NewWriter()
+	fmt.Fprintln(outf, prompt)
+	return nil
+}
+
+func (r DefaultConsoleReader) Print(prompt string) error {
+	outf := NewWriter()
+	fmt.Fprint(outf, prompt)
+	return nil
+}
+
+func (r DefaultConsoleReader) Println(prompt string) error {
+	outf := NewWriter()
+	fmt.Fprintln(outf, prompt)
+	return nil
+}
+
 func (r DefaultConsoleReader) ReadLine(prompt string) (string, error) {
-	scanner := bufio.NewScanner(os.Stdin)
-	fmt.Fprint(os.Stderr, prompt)
+	scanner := NewScanner()
+	outf := NewWriter()
+	fmt.Fprint(outf, prompt)
 	var s string
 	scanner.Scan()
 	if scanner.Err() != nil {
@@ -62,8 +66,9 @@ func (r DefaultConsoleReader) ReadInt(prompt string) (int, error) {
 }
 
 func (r DefaultConsoleReader) ReadPassword(prompt string) (string, error) {
-	fmt.Fprint(os.Stderr, prompt)
-	var pass, err = terminal.ReadPassword(int(syscall.Stdin))
+	outf := NewWriter()
+	fmt.Fprint(outf, prompt)
+	pass, err := terminal.ReadPassword(int(syscall.Stdin))
 
 	if err != nil {
 		return "", err

--- a/console/ConsoleReader_unix.go
+++ b/console/ConsoleReader_unix.go
@@ -1,0 +1,19 @@
+package console
+
+import (
+	"bufio"
+	"log"
+	"os"
+)
+
+func NewScanner() *bufio.Scanner {
+	tty, err := os.Open("/dev/tty")
+	if err != nil {
+		log.Fatalf("can't open /dev/tty: %s", err)
+	}
+	return bufio.NewScanner(tty)
+}
+
+func NewWriter() *os.File {
+	return os.Stdin
+}

--- a/console/ConsoleReader_unix.go
+++ b/console/ConsoleReader_unix.go
@@ -14,6 +14,6 @@ func NewScanner() *bufio.Scanner {
 	return bufio.NewScanner(tty)
 }
 
-func NewWriter() *os.File {
+func NewPromptWriter() *os.File {
 	return os.Stdin
 }

--- a/console/ConsoleReader_unix.go
+++ b/console/ConsoleReader_unix.go
@@ -1,3 +1,5 @@
+// +build darwin linux
+
 package console
 
 import (

--- a/console/ConsoleReader_unix.go
+++ b/console/ConsoleReader_unix.go
@@ -14,6 +14,6 @@ func NewScanner() *bufio.Scanner {
 	return bufio.NewScanner(tty)
 }
 
-func NewPromptWriter() *os.File {
-	return os.Stdin
+func NewPromptWriter() *bufio.Writer {
+	return bufio.NewWriter(os.Stdin)
 }

--- a/console/ConsoleReader_windows.go
+++ b/console/ConsoleReader_windows.go
@@ -9,6 +9,6 @@ func NewScanner() *bufio.Scanner {
 	return bufio.NewScanner(os.Stdin)
 }
 
-func NewPromptWriter() os.File {
-	return os.Stderr
+func NewPromptWriter() *bufio.Writer {
+	return bufio.NewWriter(os.Stderr)
 }

--- a/console/ConsoleReader_windows.go
+++ b/console/ConsoleReader_windows.go
@@ -9,6 +9,6 @@ func NewScanner() *bufio.Scanner {
 	return bufio.NewScanner(os.Stdin)
 }
 
-func NewWriter() os.File {
+func NewPromptWriter() os.File {
 	return os.Stderr
 }

--- a/console/ConsoleReader_windows.go
+++ b/console/ConsoleReader_windows.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package console
 
 import (

--- a/console/ConsoleReader_windows.go
+++ b/console/ConsoleReader_windows.go
@@ -1,0 +1,14 @@
+package console
+
+import (
+	"bufio"
+	"os"
+)
+
+func NewScanner() *bufio.Scanner {
+	return bufio.NewScanner(os.Stdin)
+}
+
+func NewWriter() os.File {
+	return os.Stderr
+}

--- a/credential-process.go
+++ b/credential-process.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2019 D2L Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package bmx
 
 import (

--- a/credential-process.go
+++ b/credential-process.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2019 D2L Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bmx
+
+import (
+	"encoding/json"
+	"log"
+	"time"
+
+	"github.com/jrbeverly/bmx/saml/identityProviders"
+
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/jrbeverly/bmx/saml/serviceProviders"
+)
+
+type CredentialProcessCmdOptions struct {
+	Org      string
+	User     string
+	Account  string
+	NoMask   bool
+	Password string
+	Role     string
+	Output   string
+}
+
+type CredentialProcessResult struct {
+	Version         int
+	AccessKeyId     string
+	SecretAccessKey string
+	SessionToken    string
+	Expiration      time.Time
+}
+
+func GetUserInfoFromCredentialProcessCmdOptions(printOptions CredentialProcessCmdOptions) serviceProviders.UserInfo {
+	user := serviceProviders.UserInfo{
+		Org:      printOptions.Org,
+		User:     printOptions.User,
+		Account:  printOptions.Account,
+		NoMask:   printOptions.NoMask,
+		Password: printOptions.Password,
+		Role:     printOptions.Role,
+	}
+	return user
+}
+
+func CredentialProcess(idProvider identityProviders.IdentityProvider, printOptions CredentialProcessCmdOptions) string {
+	printOptions.User = getUserIfEmpty(printOptions.User)
+	user := GetUserInfoFromCredentialProcessCmdOptions(printOptions)
+
+	saml, err := authenticate(user, idProvider)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	creds := AwsServiceProvider.GetCredentials(saml, printOptions.Role)
+	command := credentialProcessCommand(printOptions, creds)
+	return command
+}
+
+func credentialProcessCommand(printOptions CredentialProcessCmdOptions, creds *sts.Credentials) string {
+	result := &CredentialProcessResult{
+		Version:         1,
+		AccessKeyId:     *creds.AccessKeyId,
+		SecretAccessKey: *creds.SecretAccessKey,
+		SessionToken:    *creds.SessionToken,
+		Expiration:      *creds.Expiration,
+	}
+	b, err := json.Marshal(result)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}

--- a/mocks/consoleReader.go
+++ b/mocks/consoleReader.go
@@ -16,8 +16,6 @@ limitations under the License.
 
 package mocks
 
-import ()
-
 type ConsoleReaderMock struct{}
 
 func (r ConsoleReaderMock) ReadLine(prompt string) (string, error) {
@@ -30,4 +28,8 @@ func (r ConsoleReaderMock) ReadInt(prompt string) (int, error) {
 
 func (r ConsoleReaderMock) ReadPassword(prompt string) (string, error) {
 	return prompt, nil
+}
+
+func (r ConsoleReaderMock) Println(prompt string) error {
+	return nil
 }

--- a/saml/identityProviders/okta/okta.go
+++ b/saml/identityProviders/okta/okta.go
@@ -26,7 +26,6 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 
@@ -320,9 +319,9 @@ func (o *OktaClient) verifyTotpMfa(oktaAuthResponse *OktaAuthResponse, selectedF
 
 func (o *OktaClient) doMfa(oktaAuthResponse *OktaAuthResponse) error {
 	if oktaAuthResponse.Status == "MFA_REQUIRED" {
-		fmt.Fprintln(os.Stderr, "MFA Required")
+		o.ConsoleReader.Println("MFA Required")
 		for idx, factor := range oktaAuthResponse.Embedded.Factors {
-			fmt.Fprintf(os.Stderr, "%d - %s\n", idx, factor.FactorType)
+			o.ConsoleReader.Println(fmt.Sprintf("%d - %s", idx, factor.FactorType))
 		}
 
 		var mfaIdx int


### PR DESCRIPTION
Support a `credential-process` command for supplying credentials to `awscli:credential_process`.

awscli allows for supplying credentials to a configured profile using a command provided by `credential_process` in `~/.aws/config`. The command is run by the tool, and the credentials are provided in a json format to be read by the tooling.

The usage in `~/.aws/config` can be seen below, with the authentication and account details prompted for, and supplied interactively.

```
[profile master]
output = json
credential_process = bmx credential-process --org acme --user jonathan.beverly
```

 The prompts require writing to `Stdin` in the credential process case, but this has been expanded to all prompts. Although this works in my local tests, I mark this as a non-production viable option. The reason it is likely working locally is that `Stdin` is just echoing back the result into the terminal, and this implementation will encounter compatibility issues when attempting to roll out into multiple environments (docker as an example).

For now I'm fine with the stdin implementation, as it allows me to progress onto the next requirements for getting bmx compatible with a MacOS + okta push environment.