### PR TITLE
Create the session storage directory if not exists

### DIFF
--- a/profile.cov
+++ b/profile.cov
@@ -1,1 +1,0 @@
-mode: count

--- a/saml/identityProviders/okta/file/oktaSession.go
+++ b/saml/identityProviders/okta/file/oktaSession.go
@@ -35,6 +35,10 @@ type OktaSessionStorage struct{}
 
 func (o *OktaSessionStorage) SaveSessions(sessions []OktaSessionCache) {
 	sessionsJSON, _ := json.Marshal(sessions)
+	bmxHome := path.Join(userHomeDir(), ".bmx")
+	if _, err := os.Stat(bmxHome); os.IsNotExist(err) {
+		os.MkdirAll(bmxHome, os.ModeDir|os.ModePerm)
+	}
 	ioutil.WriteFile(path.Join(userHomeDir(), ".bmx", "sessions"), sessionsJSON, 0644)
 }
 


### PR DESCRIPTION
Create the session storage directory if it does not exist, allowing use of session in subsequent runs.

This resolves an issue when running in the context of a git commit hook. Specifically, when calling a command within the hook that handles its own credential assumption, it will not have a valid device (inappropriate ioctl) to work with. The calls from the commit hook script itself can be interactive and handle authentication.

By ensuring that the directory is created after authentication, this helps reduce the likelihood of encountering scenarios where a pipe is unavailable.