### PR TITLE
License adjustments in the source code & minor fixes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -186,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2019 D2L Corporation
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -87,10 +87,11 @@ Usage:
    [command]
 
 Available Commands:
-  help        Help about any command
-  print       Print to screen
-  version     Print BMX version and exit
-  write       Write to aws credential file
+  credential-process Credentials to awscli
+  help               Help about any command
+  print              Print to screen
+  version            Print BMX version and exit
+  write              Write to aws credential file
 
 Flags:
   -h, --help   help for this command

--- a/saml/serviceProviders/aws/provider_test.go
+++ b/saml/serviceProviders/aws/provider_test.go
@@ -26,8 +26,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 
-	awsService "github.com/jrbeverly/bmx/saml/serviceProviders/aws"
 	"github.com/aws/aws-sdk-go/service/sts"
+	awsService "github.com/jrbeverly/bmx/saml/serviceProviders/aws"
 )
 
 type stsMock struct {


### PR DESCRIPTION
Fill in the LICENSE with missing corporation & year inputs pulled from file headers.

The apache license version 2.0 documentation covers how to apply the license to your work: https://www.apache.org/licenses/LICENSE-2.0#apply. Based on this process, I have updated the LICENSE itself with the year and corporation outputs.

A note on file headers for each of the sources. This does not appear to be necessary for Apache2 unless you are intending to distribute files individually included in this project (in some manner). The exact requirement can be read in the policy https://www.apache.org/legal/src-headers.html (or FAQ: https://infra.apache.org/apply-license.html#copy-per-file)

Although these headers are likely not needed, they cannot be removed unless by an member of D2L Corporation as per the license requirements of Apache2.